### PR TITLE
add support for custom header

### DIFF
--- a/DrawBot.roboFontExt/lib/installDrawbot.py
+++ b/DrawBot.roboFontExt/lib/installDrawbot.py
@@ -87,15 +87,15 @@ class OpenFilesInDrawBotController(object):
         addObserver(self, "openFile", "applicationOpenFile")
 
     def openFile(self, notification):
-        if getExtensionDefault("com.drawBot.openPyFileDirectly", False):
-            fileHandler = notification["fileHandler"]
-            path = notification["path"]
-            _, ext = os.path.splitext(path)
-            if ext.lower() == ".py":
-                with open(path) as file:
-                    header = file.readline().strip('\n')
-                    if header.lower() == "#!drawbot":
-                        DrawBotController().open(path)
-                        fileHandler["opened"] = True
+        fileHandler = notification["fileHandler"]
+        path = notification["path"]
+        _, ext = os.path.splitext(path)
+        if ext.lower() == ".py":
+            with open(path) as file:
+                header = file.readline().strip('\n')
+                # dont be strict about case or whitespace
+                if header.lower().replace(" ", "") == "#drawbot" or getExtensionDefault("com.drawBot.openPyFileDirectly", False)::
+                    DrawBotController().open(path)
+                    fileHandler["opened"] = True
 
 OpenFilesInDrawBotController()

--- a/DrawBot.roboFontExt/lib/installDrawbot.py
+++ b/DrawBot.roboFontExt/lib/installDrawbot.py
@@ -92,7 +92,10 @@ class OpenFilesInDrawBotController(object):
             path = notification["path"]
             _, ext = os.path.splitext(path)
             if ext.lower() == ".py":
-                DrawBotController().open(path)
-                fileHandler["opened"] = True
+                with open(path) as file:
+                    header = file.readline().strip('\n')
+                    if header.lower() == "#!drawbot":
+                        DrawBotController().open(path)
+                        fileHandler["opened"] = True
 
 OpenFilesInDrawBotController()


### PR DESCRIPTION
Hey! I really like the "opening in drawbot by default" feature but I find that I don't want it to _always_ do that. I added support for a custom header that can be put in a users' script to open it in drawbot.

```python
#!drawbot


def restOfScript(something=True):
    pass
```
